### PR TITLE
FEC-10808 add support in optional adapterData for OTT medias

### DIFF
--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
@@ -15,9 +15,13 @@ package com.kaltura.playkit.plugins.googlecast.caf;
 
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.TextTrackStyle;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.kaltura.playkit.plugins.googlecast.caf.adsconfig.AdsConfig;
 import com.kaltura.playkit.plugins.googlecast.caf.basic.Caption;
 
@@ -26,6 +30,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.List;
+import java.util.Map;
 
 
 class KalturaCastInfo {
@@ -45,6 +50,8 @@ class KalturaCastInfo {
     public static final String FORMATS = "formats";
     public static final String STREAMER_TYPE = "streamerType";
     public static final String URL_TYPE = "urlType";
+    public static final String ADAPTER_DATA = "adapterData";
+
 
 
     private String mediaEntryId;
@@ -64,6 +71,7 @@ class KalturaCastInfo {
     private CAFCastBuilder.HttpProtocol protocol;
     private CAFCastBuilder.KalturaStreamerType streamerType;
     private CAFCastBuilder.KalturaUrlType urlType;
+    private Map<String,String> adapterData;
     private String fileIds; // 'FILE_ID1,FILE_ID2'
     private List<String> formats; //['Device_Format_1', 'Device_Format_2', 'Device_Format_3']
 
@@ -108,6 +116,28 @@ class KalturaCastInfo {
 
     public MediaMetadata getMediaMetadata() {
         return mediaMetadata;
+    }
+
+    public Map<String, String> getAdapterData() {
+        return adapterData;
+    }
+
+    @Nullable
+    public JsonObject getAdapterDataJson() {
+        if (adapterData == null || adapterData.isEmpty()) {
+            return null;
+        }
+        
+        JsonObject adapterDataJson = new JsonObject();
+        for (Map.Entry<String,String> adapterDataEntry : adapterData.entrySet()) {
+            JsonObject adapterDataItemJsonInternal = new JsonObject();
+            if (adapterDataEntry == null || TextUtils.isEmpty(adapterDataEntry.getValue())) {
+                continue;
+            }
+            adapterDataItemJsonInternal.addProperty("value", adapterDataEntry.getValue());
+            adapterDataJson.add(adapterDataEntry.getKey(), adapterDataItemJsonInternal);
+        }
+        return adapterDataJson;
     }
 
     public KalturaCastInfo setMediaMetadata(MediaMetadata mediaMetadata) {
@@ -213,6 +243,13 @@ class KalturaCastInfo {
         return this;
     }
 
+    public KalturaCastInfo setAdapterData(Map<String,String> adapterData) {
+        if (adapterData != null && !adapterData.isEmpty()) {
+            this.adapterData = adapterData;
+        }
+        return this;
+    }
+
     public List<Caption> getExternalVttCaptions() {
         return externalVttCaptions;
     }
@@ -241,6 +278,9 @@ class KalturaCastInfo {
             }
             if (getProtocol() != null) {
                 mediaData.put(PROTOCOL, getProtocol().value);
+            }
+            if (getAdapterData() != null) {
+                mediaData.put(ADAPTER_DATA, getAdapterDataJson());
             }
             if (getStreamerType() != null) {
                 mediaData.put(STREAMER_TYPE, getStreamerType().value);

--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
@@ -20,8 +20,6 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.TextTrackStyle;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import com.kaltura.playkit.plugins.googlecast.caf.adsconfig.AdsConfig;
 import com.kaltura.playkit.plugins.googlecast.caf.basic.Caption;
 

--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
@@ -285,7 +285,7 @@ class KalturaCastInfo {
             if (getProtocol() != null) {
                 mediaData.put(PROTOCOL, getProtocol().value);
             }
-            if (getAdapterData() != null) {
+            if (getAdapterData() != null && !getAdapterData().isEmpty()) {
                 mediaData.put(ADAPTER_DATA, getAdapterDataJson());
             }
             if (getStreamerType() != null) {

--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
@@ -123,19 +123,25 @@ class KalturaCastInfo {
     }
 
     @Nullable
-    public JsonObject getAdapterDataJson() {
+    public JSONObject getAdapterDataJson() {
         if (adapterData == null || adapterData.isEmpty()) {
             return null;
         }
-        
-        JsonObject adapterDataJson = new JsonObject();
-        for (Map.Entry<String,String> adapterDataEntry : adapterData.entrySet()) {
-            JsonObject adapterDataItemJsonInternal = new JsonObject();
-            if (adapterDataEntry == null || TextUtils.isEmpty(adapterDataEntry.getValue())) {
-                continue;
+        JSONObject adapterDataJson = new JSONObject();
+
+        try {
+            for (Map.Entry<String,String> adapterDataEntry : adapterData.entrySet()) {
+                JSONObject adapterDataItemJsonInternal = new JSONObject();
+                if (adapterDataEntry == null || TextUtils.isEmpty(adapterDataEntry.getValue())) {
+                    continue;
+                }
+
+                adapterDataItemJsonInternal.put("value", adapterDataEntry.getValue());
+                adapterDataJson.put(adapterDataEntry.getKey(), adapterDataItemJsonInternal);
             }
-            adapterDataItemJsonInternal.addProperty("value", adapterDataEntry.getValue());
-            adapterDataJson.add(adapterDataEntry.getKey(), adapterDataItemJsonInternal);
+        }
+        catch (JSONException e) {
+            return null;
         }
         return adapterDataJson;
     }

--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaPhoenixCastBuilder.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaPhoenixCastBuilder.java
@@ -13,7 +13,7 @@
 package com.kaltura.playkit.plugins.googlecast.caf;
 
 import java.util.List;
-
+import java.util.Map;
 
 
 public class KalturaPhoenixCastBuilder extends CAFCastBuilder<KalturaPhoenixCastBuilder> {
@@ -54,6 +54,11 @@ public class KalturaPhoenixCastBuilder extends CAFCastBuilder<KalturaPhoenixCast
 
     public KalturaPhoenixCastBuilder setUrlType(KalturaUrlType urlType) {
         castInfo.setUrlType(urlType);
+        return this;
+    }
+
+    public KalturaPhoenixCastBuilder setAdapterData(Map<String,String> adapterData) {
+        castInfo.setAdapterData(adapterData);
         return this;
     }
 }


### PR DESCRIPTION
 adding    .setAdapterData(adapterDataMap)

```
var adapterDataMap = mutableMapOf<String,String>()
        var key1:String = "aaa"
        var key2:String = "ccc"

        adapterDataMap.put(key1, key2)
        adapterDataMap.put(key2, key1)

        val phoenixCastBuilder = KalturaPhoenixCastBuilder()
                .setMediaEntryId(mediaId)
                .setKs("")
                .setFormats(formats)
                .setStreamType(CAFCastBuilder.StreamType.VOD)
                .setAssetReferenceType(CAFCastBuilder.AssetReferenceType.Media)
                .setContextType(CAFCastBuilder.PlaybackContextType.Playback)
                .setMediaType(CAFCastBuilder.KalturaAssetType.Media)
                .setUrlType(CAFCastBuilder.KalturaUrlType.PlayManifest)
                .setAdapterData(adapterDataMap)
                .setProtocol(protocol)
```