### PR TITLE
FEC-10818 - add support for referenceId

### DIFF
--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/CAFCastBuilder.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/CAFCastBuilder.java
@@ -148,6 +148,11 @@ public abstract class CAFCastBuilder<T extends CAFCastBuilder<T>> {
         return (T) this;
     }
 
+    public T setReferenceId(@NonNull String referenceId) {
+        castInfo.setReferenceId(referenceId);
+        return (T) this;
+    }
+    
     public T setMetadata(@NonNull MediaMetadata mediaMetadata) {
         castInfo.setMediaMetadata(mediaMetadata);
         return (T) this;
@@ -282,7 +287,7 @@ public abstract class CAFCastBuilder<T extends CAFCastBuilder<T>> {
 
     private void validate(KalturaCastInfo castInfo) throws IllegalArgumentException {
 
-        if (TextUtils.isEmpty(castInfo.getMediaEntryId())) {
+        if (TextUtils.isEmpty(castInfo.getMediaEntryId()) && TextUtils.isEmpty(castInfo.getReferenceId())) {
             throw new IllegalArgumentException();
         }
 

--- a/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
+++ b/googlecast/src/main/java/com/kaltura/playkit/plugins/googlecast/caf/KalturaCastInfo.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 class KalturaCastInfo {
     public static final String ENTRY_ID = "entryId";
+    public static final String REFERENCE_ID = "referenceId";
     public static final String KS = "ks";
     public static final String MEDIA_INFO = "mediaInfo";
     public static final String TEXT_LANGUAGE = "textLanguage";
@@ -53,6 +54,7 @@ class KalturaCastInfo {
 
 
     private String mediaEntryId;
+    private String referenceId;            // optional in OVP instead of mediaEntryId
     private String ks;                     // optional
     private String textLanguage;           // optional
     private String audioLanguage;          // optional
@@ -80,11 +82,20 @@ class KalturaCastInfo {
         return mediaEntryId;
     }
 
+    public String getReferenceId() {
+        return referenceId;
+    }
+
     public KalturaCastInfo setMediaEntryId(String mediaEntryId) {
         this.mediaEntryId = mediaEntryId;
         return this;
     }
 
+    public KalturaCastInfo setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+        return this;
+    }
+    
     public String getKs() {
         return ks;
     }
@@ -266,7 +277,11 @@ class KalturaCastInfo {
         JSONObject customData = new JSONObject();
         try {
             JSONObject mediaData = new JSONObject();
-            mediaData.put(ENTRY_ID, getMediaEntryId());
+            if (!TextUtils.isEmpty(getMediaEntryId())) {
+                mediaData.put(ENTRY_ID, getMediaEntryId());
+            } else if (!TextUtils.isEmpty(getReferenceId())) {
+                mediaData.put(REFERENCE_ID, getReferenceId());
+            }
             if (!TextUtils.isEmpty(getKs())) {
                 mediaData.put(KS, getKs());
             }


### PR DESCRIPTION
cast for OVP media with referenced

###Example:
referenceId": "Alex1234"

Cast Receiver Id: B202D11C

PartnerId: 1091 (QA)

```
private fun getOvpCastMediaInfo(entryId: String, adTagUrl: String, adTagType: CAFCastBuilder.AdTagType?, externalVttCaptions: List<Caption>?): MediaInfo {

        val ovpV3CastBuilder = KalturaCastBuilder()
                //.setMediaEntryId(entryId)
                .setKs("")
                .setReferenceId(entryId)
                .setStreamType(CAFCastBuilder.StreamType.VOD)

        if (externalVttCaptions != null) {
            ovpV3CastBuilder.setExternalVttCaptions(externalVttCaptions)
        }

        if (!TextUtils.isEmpty(adTagUrl)) {
            if (adTagType == CAFCastBuilder.AdTagType.VAST) {
                ovpV3CastBuilder.setAdsConfig(createAdsConfigVast(adTagUrl))
            } else {
                ovpV3CastBuilder.setAdsConfig(createAdsConfigVmap(adTagUrl))
            }
        }
        //ovpV3CastBuilder.setDefaultTextLangaugeCode("en")
        return returnResult(ovpV3CastBuilder)
    }
```
